### PR TITLE
Export helper types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,27 +1,28 @@
 import Buffer, { BufferEncoding } from 'bare-buffer'
 
+interface Import {
+  specifier: string
+  type: number
+  names: string[]
+  position: [importStart: number, specifierStart: number, specifierEnd: number]
+}
+
+interface Export {
+  name: string
+  position: [exportStart: number, nameStart: number, nameEnd: number]
+}
+
 declare function lex(
   input: string | Buffer,
   encoding?: BufferEncoding
 ): {
-  imports: {
-    specifier: string
-    type: number
-    names: string[]
-    position: [
-      importStart: number,
-      specifierStart: number,
-      specifierEnd: number
-    ]
-  }[]
-
-  exports: {
-    name: string
-    position: [exportStart: number, nameStart: number, nameEnd: number]
-  }[]
+  imports: Import[]
+  exports: Export[]
 }
 
 declare namespace lex {
+  export { type Import, type Export }
+
   export const constants: {
     REQUIRE: number
     IMPORT: number


### PR DESCRIPTION
Facilitate reuse, needing the `Import` type for https://github.com/holepunchto/bare-module-traverse/blob/c2fbeaa7d6eea91c153ce549e3708e28a1754d64/lib/resolve/default.js#L4 `entry` argument.